### PR TITLE
add customizable number formatting

### DIFF
--- a/aeson-pretty.cabal
+++ b/aeson-pretty.cabal
@@ -44,6 +44,7 @@ library
         base >= 4.5,
         bytestring >= 0.9,
         vector >= 0.9,
+        scientific >= 0.3,
         text >= 0.11,
         unordered-containers >= 0.1.3.0
 


### PR DESCRIPTION
```
$ cat tst
100000
10
1.2345
0.1
0.00001234

$ aeson-pretty < tst
100000
10
1.2345
0.1
1.234e-5

$ aeson-pretty -f=Exponent < tst
100000
10
1.2345e0
1.0e-1
1.234e-5

$ aeson-pretty -f=Fixed < tst
100000
10
1.2345
0.1
0.00001234
```