### PR TITLE
Fix build failures for GHC < 7.10

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 dist
+dist-newstyle
 cabal-dev
 *.json
 .cabal-sandbox

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,36 @@
+language: c
+sudo: false
+
+cache:
+  directories:
+    - $HOME/.cabal/packages
+
+matrix:
+  include:
+    - env: CABALVER=1.18 GHCVER=7.4.2
+      compiler: ": #GHC 7.4.2"
+      addons: {apt: {packages: [cabal-install-1.18,ghc-7.4.2,alex-3.1.7,happy-1.19.5], sources: [hvr-ghc]}}
+    - env: CABALVER=1.18 GHCVER=7.6.3
+      compiler: ": #GHC 7.6.3"
+      addons: {apt: {packages: [cabal-install-1.18,ghc-7.6.3,alex-3.1.7,happy-1.19.5], sources: [hvr-ghc]}}
+    - env: CABALVER=1.18 GHCVER=7.8.4
+      compiler: ": #GHC 7.8.4"
+      addons: {apt: {packages: [cabal-install-1.18,ghc-7.8.4,alex-3.1.7,happy-1.19.5], sources: [hvr-ghc]}}
+    - env: CABALVER=1.22 GHCVER=7.10.3
+      compiler: ": #GHC 7.10.3"
+      addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.3,alex-3.1.7,happy-1.19.5], sources: [hvr-ghc]}}
+
+before_install:
+ - export HAPPYVER=1.19.5
+ - export ALEXVER=3.1.7
+ - export PATH=~/.cabal/bin:/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:/opt/happy/$HAPPYVER/bin:/opt/alex/$ALEXVER/bin:$PATH
+
+install:
+ - cabal --version
+ - echo "$(ghc --version) [$(ghc --print-project-git-commit-id 2> /dev/null || echo '?')]"
+ - travis_retry cabal update
+ - cabal install --only-dependencies --enable-tests --enable-benchmarks
+
+script:
+ - cabal configure --enable-tests -v2
+ - cabal build

--- a/Data/Aeson/Encode/Pretty.hs
+++ b/Data/Aeson/Encode/Pretty.hs
@@ -69,6 +69,8 @@ import Data.Text.Lazy.Builder (Builder, toLazyText)
 import Data.Text.Lazy.Builder.Scientific (formatScientificBuilder)
 import Data.Text.Lazy.Encoding (encodeUtf8)
 import qualified Data.Vector as V (toList)
+import Prelude ()
+import Prelude.Compat
 
 
 data PState = PState { pLevel     :: Int

--- a/aeson-pretty.cabal
+++ b/aeson-pretty.cabal
@@ -42,6 +42,7 @@ library
     build-depends:
         aeson >= 0.7,
         base >= 4.5,
+        base-compat >= 0.9 && < 0.10,
         bytestring >= 0.9,
         scientific >= 0.3,
         vector >= 0.9,


### PR DESCRIPTION
`mconcat` had to be imported. I switched to `base-compat` rather than going down the road of ever-increasing CPP.

I also added a travis file with GHC versions which the package claims to support. I think it would make sense to enable travis for this repo before merging on releasing since locally I only checked that 7.10 builds. 