### PR TITLE
Bring back Aeson number formatting as the default.

### DIFF
--- a/Data/Aeson/Encode/Pretty.hs
+++ b/Data/Aeson/Encode/Pretty.hs
@@ -87,7 +87,9 @@ data PState = PState { pLevel     :: Int
 data Indent = Spaces Int | Tab
 
 data NumberFormat
-  -- | Use decimal notation for values between 0.1 and 9,999,999, and scientific
+  -- | The standard behaviour of the 'Aeson.encode' function. Uses
+  --   integer literals for integers (1, 2, 3...), simple decimals
+  --   for fractional values between 0.1 and 9,999,999, and scientific
   --   notation otherwise.
   = Generic
   -- | Scientific notation (e.g. 2.3e123).
@@ -195,7 +197,7 @@ fromIndent PState{..} = mconcat (replicate pLevel pIndent)
 
 fromNumber :: PState -> S.Scientific -> Builder
 fromNumber st x = case pNumFormat st of
-  Generic    -> formatScientificBuilder S.Generic Nothing x
+  Generic    -> Aeson.encodeToTextBuilder $ Number x
   Scientific -> formatScientificBuilder S.Exponent Nothing x
   Decimal    -> formatScientificBuilder S.Fixed Nothing x
   Custom f   -> f x


### PR DESCRIPTION
This default is actually quite sensible: not only does it reasonably switch between fixed-decimal and scientific notation, it also discerns fractional from integral numbers.

The new `Generic` option will simply print _all_ numbers in floating-point format, which is frankly a bit obnoxious seeing as JSON is a dynamic format and uses `Number` for numbers of any type. E.g. `17.0` is not really an integer, is it?

Perhaps it would be better to tweak `Generic` to have this behaviour, but I suppose some people actually want all numbers in decimal format.

(For what it's worth: in my optinion the `.0` notation does _never_ make sense – only in weak languages like C is it ever necessary to designate integral numbers as floating-point, and here the correct way of writing should be just `17.`, without a leading zero. And in both Haskell and JavaScript there's no reason to give any integral numbers decimal suffix at all.)