### PR TITLE
Format large numbers in scientific format by default.

### DIFF
--- a/Data/Aeson/Encode/Pretty.hs
+++ b/Data/Aeson/Encode/Pretty.hs
@@ -197,7 +197,9 @@ fromIndent PState{..} = mconcat (replicate pLevel pIndent)
 
 fromNumber :: PState -> S.Scientific -> Builder
 fromNumber st x = case pNumFormat st of
-  Generic    -> Aeson.encodeToTextBuilder $ Number x
+  Generic
+    | (x > 1.0e19 || x < -1.0e19) -> formatScientificBuilder S.Exponent Nothing x
+    | otherwise -> Aeson.encodeToTextBuilder $ Number x
   Scientific -> formatScientificBuilder S.Exponent Nothing x
   Decimal    -> formatScientificBuilder S.Fixed Nothing x
   Custom f   -> f x


### PR DESCRIPTION
Default to scientific formatting even to large integer numbers (larger than a million in magnitude). Reasons:

1. `Aeson` does not preserve type information (integers vs doubles) on purpose.

2. Large integer numbers are hard to read.

3. If for some reason Double value is not initialized, it may have exponent of about `300`. Since its mantissa part is much smaller, it will look like large integer. And, therefore be serialized to several lines of zeroes.