### PR TITLE
Add in-place operations to CLI tool.

### DIFF
--- a/aeson-pretty.cabal
+++ b/aeson-pretty.cabal
@@ -27,6 +27,11 @@ description:
         > cabal install -flib-only aeson-pretty
     .
     the command-line tool will NOT be installed.
+    .
+    For those wishing to prettify JSON in their source repos, you can now pass
+    multiple paths using @find@ or @xargs@ and they will be processed in place.
+    No backups are made, so this is best used with a VCS.
+    .
 
 extra-source-files:
     README.markdown
@@ -69,7 +74,9 @@ executable aeson-pretty
             attoparsec >= 0.10,
             base == 4.*,
             bytestring >= 0.9,
-            cmdargs >= 0.7
+            cmdargs >= 0.7,
+            directory,
+            filepath
 
     ghc-options: -Wall
     ghc-prof-options: -auto-all


### PR DESCRIPTION
- Same operation as before when no paths passed.
- Ignores stdin/stdout when paths passed and processes paths in place.

This is for the case where you have a bunch of JSON that ought to be prettified when building, and you want to run `find json-stuff -name \*.json -exec aeson-pretty {} +` against it.

I've also tested it with the `stack-7.10.yaml`, and against a bunch of JSON files I had, and it seems Good To Go.