### PR TITLE
Document that `NumberFormat` deviates from aeson

### DIFF
--- a/Data/Aeson/Encode/Pretty.hs
+++ b/Data/Aeson/Encode/Pretty.hs
@@ -95,10 +95,11 @@ data PState = PState { pLevel     :: Int
 data Indent = Spaces Int | Tab
 
 data NumberFormat
-  -- | The standard behaviour of the 'Aeson.encode' function. Uses
-  --   integer literals for integers (1, 2, 3...), simple decimals
-  --   for fractional values between 0.1 and 9,999,999, and scientific
-  --   notation otherwise.
+  -- | For numbers with absolute value less than 1e19, this follows the standard
+  -- behaviour of the 'Data.Aeson.encode' function. Uses integer literals for
+  -- integers (1, 2, 3...), simple decimals for fractional values between 0.1
+  -- and 9,999,999, and scientific notation otherwise. For numbers with an
+  -- absolute value larger than 1e19, always uses scientific notation.
   = Generic
   -- | Scientific notation (e.g. 2.3e123).
   | Scientific


### PR DESCRIPTION
PR #23 changed the output format for `confNumFormat=Generic` after deliberate discussion. However, the documentation still refers to the old situation. This caught us by surprise while formatting very large integers.

I propose to adjust the documentation to accurately reflect the behaviour.

Incidentally, I fixed a broken link to `aeson`'s `encode` function.